### PR TITLE
feat: add monthly stats and recent trends to dashboard

### DIFF
--- a/app.json
+++ b/app.json
@@ -15,18 +15,12 @@
       "**/*"
     ],
     "ios": {
-      "supportsTablet": true,
-      "iosStatusBar": {
-        "translucent": false
-      }
+      "supportsTablet": true
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#965FDC"
-      },
-      "androidStatusBar": {
-        "translucent": false
       }
     },
     "web": {

--- a/app.json
+++ b/app.json
@@ -15,12 +15,18 @@
       "**/*"
     ],
     "ios": {
-      "supportsTablet": true
+      "supportsTablet": true,
+      "iosStatusBar": {
+        "translucent": false
+      }
     },
     "android": {
       "adaptiveIcon": {
         "foregroundImage": "./assets/adaptive-icon.png",
         "backgroundColor": "#965FDC"
+      },
+      "androidStatusBar": {
+        "translucent": false
       }
     },
     "web": {

--- a/components/home/CategoryItem.tsx
+++ b/components/home/CategoryItem.tsx
@@ -1,0 +1,61 @@
+import { StyleSheet, View } from "react-native";
+import { FC, useMemo } from "react";
+import { ExpenseCategory } from "../../types/expenses";
+import { Theme } from "../../constants/colours";
+import { useTheme } from "../../context/ThemeContext";
+import { Ionicons } from "@expo/vector-icons";
+import { getCategoryIconName } from "../../utils/expenses";
+import Text from "../ui/text/Text";
+
+interface Props {
+  category: ExpenseCategory;
+  spend?: number;
+  count?: number;
+}
+
+const CategoryItem: FC<Props> = ({ category, spend, count }) => {
+  const { theme } = useTheme();
+  const styles = useMemo(() => styling(theme), [theme]);
+
+  return (
+    <View style={styles.container}>
+      <View style={styles.iconContainer}>
+        <Ionicons
+          name={getCategoryIconName(category)}
+          size={24}
+          color={theme.primary}
+        />
+      </View>
+      <Text style={styles.text}>{category}</Text>
+      {spend !== undefined && (
+        <Text style={styles.text}>${spend.toFixed(2)}</Text>
+      )}
+      {count !== undefined && (
+        <Text style={styles.text}>{count.toLocaleString()}</Text>
+      )}
+    </View>
+  );
+};
+
+export default CategoryItem;
+
+const styling = (theme: Theme) => StyleSheet.create({
+  container: {
+    justifyContent: "center",
+    alignItems: "center",
+    gap: 5,
+    width: 90,
+  },
+  iconContainer: {
+    justifyContent: "center",
+    alignItems: "center",
+    height: 50,
+    width: 50,
+    backgroundColor: theme.background,
+    borderRadius: 100,
+  },
+  text: {
+    textAlign: "center",
+    fontFamily: "Roboto-Medium",
+  },
+});

--- a/components/home/MonthlyStats.tsx
+++ b/components/home/MonthlyStats.tsx
@@ -1,0 +1,71 @@
+import { FC, useMemo } from "react";
+import { StyleSheet, View } from "react-native";
+import { getCurrentMonthName } from "../../utils/date";
+import { useExpenses } from "../../context/ExpenseContext";
+import { getCurrentMonthStats } from "../../utils/expenses";
+import Heading from "../ui/text/Heading";
+import Text from "../ui/text/Text";
+import StatCard from "./StatCard";
+import CategoryItem from "./CategoryItem";
+
+const MonthlyStats: FC = () => {
+  const { expenses } = useExpenses();
+
+  const stats = useMemo(() => getCurrentMonthStats(expenses), [expenses]);
+
+  return (
+    <StatCard>
+      <View style={{ rowGap: 20 }}>
+        <Heading>{getCurrentMonthName()} Stats</Heading>
+        <Text style={styles.statHeading}>
+          Total spend: ${stats.spend.toFixed(2)}
+        </Text>
+        <View>
+          <Text style={styles.statHeading}>Highest spending categories</Text>
+          <View style={styles.categoriesContainer}>
+            {stats.categoryStats.slice(0, 3).map((categoryStat, index) => (
+              <CategoryItem
+                key={index}
+                category={categoryStat.category}
+                spend={categoryStat.totalSpend}
+              />
+            ))}
+          </View>
+        </View>
+        <View>
+          <Text style={styles.statHeading}>Most frequent categories</Text>
+          <View style={styles.categoriesContainer}>
+            {[...stats.categoryStats]
+              .sort((a, b) => b.count - a.count)
+              .slice(0, 3)
+              .map((categoryStat, index) => (
+                <CategoryItem
+                  key={index}
+                  category={categoryStat.category}
+                  count={categoryStat.count}
+                />
+              ))}
+          </View>
+        </View>
+      </View>
+    </StatCard>
+  );
+};
+
+export default MonthlyStats;
+
+const styles = StyleSheet.create({
+  statHeading: {
+    fontFamily: "Roboto-Medium",
+    fontSize: 16,
+  },
+  categoriesContainer: {
+    width: "100%",
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "flex-start",
+    flexWrap: "wrap",
+    gap: 10,
+    paddingTop: 20,
+  },
+});

--- a/components/home/RecentTrends.tsx
+++ b/components/home/RecentTrends.tsx
@@ -1,0 +1,62 @@
+import { FC, useMemo } from "react";
+import { StyleSheet, View } from "react-native";
+import { useExpenses } from "../../context/ExpenseContext";
+import { getRecentTrends } from "../../utils/expenses";
+import StatCard from "./StatCard";
+import Heading from "../ui/text/Heading";
+import Text from "../ui/text/Text";
+import SpendingChart from "./SpendingChart";
+import CategoryItem from "./CategoryItem";
+
+const RecentTrends: FC = () => {
+  const { expenses } = useExpenses();
+  const trends = useMemo(() => getRecentTrends(expenses), [expenses]);
+
+  return (
+    <StatCard>
+      <View style={{ rowGap: 20 }}>
+        <Heading>Recent Trends</Heading>
+        <Text style={styles.statHeading}>
+          Spending in last 3 months: ${trends.spend.toFixed(2)}
+        </Text>
+        <View>
+          <Text style={styles.statHeading}>Monthly spending comparison</Text>
+          <SpendingChart
+            monthlySpend={trends.monthlySpend}
+            totalSpend={trends.spend}
+          />
+        </View>
+        <View>
+          <Text style={styles.statHeading}>Highest spending categories</Text>
+          <View style={styles.categoriesContainer}>
+            {trends.categoryStats.slice(0, 3).map((categoryStat, index) => (
+              <CategoryItem
+                key={index}
+                category={categoryStat.category}
+                spend={categoryStat.totalSpend}
+              />
+            ))}
+          </View>
+        </View>
+      </View>
+    </StatCard>
+  );
+};
+
+export default RecentTrends;
+
+const styles = StyleSheet.create({
+  statHeading: {
+    fontFamily: "Roboto-Medium",
+    fontSize: 16,
+  },
+  categoriesContainer: {
+    width: "100%",
+    flexDirection: "row",
+    justifyContent: "center",
+    alignItems: "flex-start",
+    flexWrap: "wrap",
+    gap: 10,
+    paddingTop: 20,
+  },
+});

--- a/components/home/SpendingChart.tsx
+++ b/components/home/SpendingChart.tsx
@@ -1,0 +1,89 @@
+import { FC, useMemo } from "react";
+import { StyleSheet, View } from "react-native";
+import { MonthSpend } from "../../utils/expenses";
+import { Theme } from "../../constants/colours";
+import { useTheme } from "../../context/ThemeContext";
+import Text from "../ui/text/Text";
+
+interface Props {
+  monthlySpend: MonthSpend[];
+  totalSpend: number;
+}
+
+const SpendingChart: FC<Props> = ({ monthlySpend, totalSpend }) => {
+  const { theme } = useTheme();
+  const styles = useMemo(() => styling(theme), [theme]);
+
+  return (
+    <View style={styles.chartContainer}>
+      <View style={styles.chart}>
+        {monthlySpend.map(({ month, spend }) => (
+          <View key={month} style={styles.columnContainer}>
+            <Text style={styles.value}>${spend.toFixed(2)}</Text>
+            <View
+              style={[
+                styles.column,
+                { height: ((spend / totalSpend) * 150) || 0 }
+              ]}
+            />
+          </View>
+        ))}
+      </View>
+      <View style={styles.xAxisHeadings}>
+        {monthlySpend.map(({ month }) => (
+          <View key={month} style={styles.monthNameContainer}>
+            <Text style={styles.monthName}>{month.substring(0, 3)}</Text>
+          </View>
+        ))}
+      </View>
+    </View>
+  );
+};
+
+export default SpendingChart;
+
+const styling = (theme: Theme) => StyleSheet.create({
+  chartContainer: {
+    marginVertical: 10,
+    alignItems: "center",
+  },
+  chart: {
+    borderBottomWidth: 1,
+    borderBottomColor: theme.border,
+    minHeight: 150,
+    width: "100%",
+    flexDirection: "row",
+    justifyContent: "space-between",
+    alignItems: "flex-end",
+  },
+  columnContainer: {
+    flex: 1,
+    justifyContent: "flex-end",
+    alignItems: "center",
+  },
+  column: {
+    backgroundColor: theme.primary,
+    borderTopLeftRadius: 10,
+    borderTopRightRadius: 10,
+    width: 70,
+  },
+  value: {
+    fontFamily: "Roboto-Medium",
+    paddingBottom: 3,
+  },
+  xAxisHeadings: {
+    flexDirection: "row",
+    alignItems: "center",
+    justifyContent: "space-between",
+    paddingTop: 10,
+    width: "100%",
+  },
+  monthNameContainer: {
+    flex: 1,
+    alignItems: "center",
+    justifyContent: "center",
+  },
+  monthName: {
+    fontFamily: "Roboto-Medium",
+  },
+});

--- a/components/home/StatCard.tsx
+++ b/components/home/StatCard.tsx
@@ -1,0 +1,25 @@
+import { FC, PropsWithChildren, useMemo } from "react";
+import { StyleSheet, View } from "react-native";
+import { useTheme } from "../../context/ThemeContext";
+import { Theme } from "../../constants/colours";
+
+const StatCard: FC<PropsWithChildren> = ({ children }) => {
+  const { theme } = useTheme();
+  const styles = useMemo(() => styling(theme), [theme]);
+
+  return (
+    <View style={styles.card}>{children}</View>
+  );
+};
+
+export default StatCard;
+
+const styling = (theme: Theme) => StyleSheet.create({
+  card: {
+    width: "100%",
+    backgroundColor: theme.card,
+    borderRadius: 10,
+    paddingHorizontal: 20,
+    paddingVertical: 30,
+  },
+});

--- a/components/ui/layout/ScrollScreenWrapper.tsx
+++ b/components/ui/layout/ScrollScreenWrapper.tsx
@@ -1,21 +1,32 @@
-import { ScrollView, StyleSheet } from "react-native";
-import { FC, PropsWithChildren } from "react";
+import { ScrollView, StyleSheet, SafeAreaView } from "react-native";
+import { FC, PropsWithChildren, useMemo } from "react";
 import ScreenWrapper from "./ScreenWrapper";
+import { Theme } from "../../../constants/colours";
+import { useTheme } from "../../../context/ThemeContext";
 
 const ScrollScreenWrapper: FC<PropsWithChildren> = ({ children }) => {
+  const { theme } = useTheme();
+  const styles = useMemo(() => styling(theme), [theme]);
+
   return (
-    <ScrollView
-      contentContainerStyle={styles.scrollWrapper}
-      alwaysBounceVertical={false}
-    >
-      <ScreenWrapper>{children}</ScreenWrapper>
-    </ScrollView>
+    <SafeAreaView style={styles.wrapper}>
+      <ScrollView
+        contentContainerStyle={styles.scrollWrapper}
+        alwaysBounceVertical={false}
+      >
+        <ScreenWrapper>{children}</ScreenWrapper>
+      </ScrollView>
+    </SafeAreaView>
   );
 };
 
 export default ScrollScreenWrapper;
 
-const styles = StyleSheet.create({
+const styling = (theme: Theme) => StyleSheet.create({
+  wrapper: {
+    backgroundColor: theme.background,
+    flex: 1,
+  },
   scrollWrapper: {
     flexGrow: 1,
     justifyContent: "center",

--- a/navigation/Navigator.tsx
+++ b/navigation/Navigator.tsx
@@ -1,10 +1,10 @@
 import { FC, useEffect } from "react";
+import { StatusBar } from "react-native";
+import { createNativeStackNavigator } from "@react-navigation/native-stack";
 import { useTheme } from "../context/ThemeContext";
 import { useAuth } from "../context/AuthContext";
-import { StatusBar } from "expo-status-bar";
-import { createNativeStackNavigator } from "@react-navigation/native-stack";
-import * as SplashScreen from "expo-splash-screen";
 import { RootStackParamList } from "../types/navigation";
+import * as SplashScreen from "expo-splash-screen";
 import RootTabs from "./RootTabs";
 import RegisterScreen from "../screens/Register";
 import LoginScreen from "../screens/Login";
@@ -15,7 +15,7 @@ import EditProfileScreen from "../screens/EditProfile";
 
 const Navigator: FC = () => {
   const Stack = createNativeStackNavigator<RootStackParamList>();
-  const { isDarkMode } = useTheme();
+  const { isDarkMode, theme } = useTheme();
   const { isAuthenticated, loading } = useAuth();
 
   // Show splash screen until auth state has loaded to prevent jumping from
@@ -28,7 +28,10 @@ const Navigator: FC = () => {
 
   return (
     <>
-      <StatusBar style={isDarkMode ? "light" : "dark"} />
+      <StatusBar
+        barStyle={isDarkMode ? "light-content" : "dark-content"}
+        backgroundColor={theme.background}
+      />
       <Stack.Navigator screenOptions={{ headerShown: false }}>
         {isAuthenticated ? (
           <Stack.Group>

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -1,30 +1,49 @@
-import { StyleSheet, View } from "react-native";
-import { FC, useMemo } from "react";
+import { ActivityIndicator, StyleSheet, View } from "react-native";
+import { FC, useCallback, useEffect, useMemo } from "react";
 import { useAuth } from "../context/AuthContext";
 import { User } from "firebase/auth";
-import { getCurrentMonthName } from "../utils/date";
 import { Theme } from "../constants/colours";
 import { useTheme } from "../context/ThemeContext";
 import ScrollScreenWrapper from "../components/ui/layout/ScrollScreenWrapper";
 import Heading from "../components/ui/text/Heading";
+import MonthlyStats from "../components/home/MonthlyStats";
+import { useExpenses } from "../context/ExpenseContext";
 
 const HomeScreen: FC = () => {
   const { user } = useAuth();
   const { theme } = useTheme();
+  const { loading, updateExpenses } = useExpenses();
   const styles = useMemo(() => styling(theme), [theme]);
+
+  const fetchExpenses = useCallback(async (user: User | null) => {
+    if (user) {
+      await updateExpenses(user.uid);
+    }
+  }, [user]);
+
+  useEffect(() => {
+    fetchExpenses(user);
+  }, [user]);
 
   return (
     <ScrollScreenWrapper>
       <View style={styles.container}>
         <Heading style={{ fontSize: 36 }}>Hi {getUserFirstName(user)}</Heading>
-        <View style={styles.statSummaryContainer}>
-          <Heading>{getCurrentMonthName()} spend</Heading>
-          <View style={styles.placeholderCard}></View>
-        </View>
-        <View style={styles.statSummaryContainer}>
-          <Heading>Your top spending categories</Heading>
-          <View style={styles.placeholderCard}></View>
-        </View>
+        {loading ? (
+          <View style={styles.loadingContainer}>
+            <ActivityIndicator color={theme.primary} size="large" />
+          </View>
+        ) : (
+          <>
+            <View style={styles.statSummaryContainer}>
+              <MonthlyStats />
+            </View>
+            <View style={styles.statSummaryContainer}>
+              <Heading>Your top spending categories</Heading>
+              <View style={styles.placeholderCard}></View>
+            </View>
+          </>
+        )}
       </View>
     </ScrollScreenWrapper>
   );
@@ -37,6 +56,11 @@ const styling = (theme: Theme) => StyleSheet.create({
     flex: 1,
     padding: 20,
     paddingTop: 50,
+  },
+  loadingContainer: {
+    flex: 1,
+    justifyContent: "center",
+    alignItems: "center",
   },
   statSummaryContainer: {
     marginTop: 30,

--- a/screens/Home.tsx
+++ b/screens/Home.tsx
@@ -2,12 +2,13 @@ import { ActivityIndicator, StyleSheet, View } from "react-native";
 import { FC, useCallback, useEffect, useMemo } from "react";
 import { useAuth } from "../context/AuthContext";
 import { User } from "firebase/auth";
-import { Theme } from "../constants/colours";
+import { useExpenses } from "../context/ExpenseContext";
 import { useTheme } from "../context/ThemeContext";
+import { Theme } from "../constants/colours";
 import ScrollScreenWrapper from "../components/ui/layout/ScrollScreenWrapper";
 import Heading from "../components/ui/text/Heading";
 import MonthlyStats from "../components/home/MonthlyStats";
-import { useExpenses } from "../context/ExpenseContext";
+import RecentTrends from "../components/home/RecentTrends";
 
 const HomeScreen: FC = () => {
   const { user } = useAuth();
@@ -39,8 +40,7 @@ const HomeScreen: FC = () => {
               <MonthlyStats />
             </View>
             <View style={styles.statSummaryContainer}>
-              <Heading>Your top spending categories</Heading>
-              <View style={styles.placeholderCard}></View>
+              <RecentTrends />
             </View>
           </>
         )}

--- a/utils/date.ts
+++ b/utils/date.ts
@@ -1,4 +1,4 @@
-const MONTH_NAMES = [
+export const MONTH_NAMES = [
   "January",
   "February",
   "March",

--- a/utils/expenses.ts
+++ b/utils/expenses.ts
@@ -18,6 +18,7 @@ import {
   FirebaseExpense,
 } from "../types/expenses";
 import { Ionicons } from "@expo/vector-icons";
+import { MONTH_NAMES } from "./date";
 
 const database = getDatabase(app);
 const dbRef = ref(database, "expenses");
@@ -98,6 +99,17 @@ interface MonthlyStats {
   categoryStats: CategoryStats[];
 }
 
+interface RecentTrends {
+  spend: number;
+  monthlySpend: MonthSpend[];
+  categoryStats: CategoryStats[];
+}
+
+export interface MonthSpend {
+  month: string;
+  spend: number;
+}
+
 interface CategoryStats {
   category: ExpenseCategory;
   count: number;
@@ -114,11 +126,50 @@ export const getCurrentMonthStats = (expenses: Expense[]): MonthlyStats => {
     expenses,
     ExpenseDateFilterOption.THIS_MONTH
   );
-  const totalSpend = expenses.reduce((accumulator, currentExpense) => {
+  const totalSpend = currentMonthExpenses.reduce((
+    accumulator,
+    currentExpense
+  ) => {
     return accumulator + currentExpense.amount;
   }, 0);
   const categoryStats = getCategoryStats(currentMonthExpenses);
   return { spend: totalSpend, categoryStats };
+};
+
+export const getRecentTrends = (expenses: Expense[]): RecentTrends => {
+  // Get expenses from past 3 months
+  const recentExpenses = [...expenses].filter((expense) => (
+    isInPastThreeMonths(expense.date)
+  ));
+  const totalSpend = recentExpenses.reduce((accumulator, currentExpense) => {
+    return accumulator + currentExpense.amount;
+  }, 0);
+  const monthlySpend = getMonthlySpend(expenses);
+  const categoryStats = getCategoryStats(recentExpenses);
+  return { spend: totalSpend, monthlySpend, categoryStats };
+};
+
+const getMonthlySpend = (expenses: Expense[]): MonthSpend[] => {
+  // Initialise map with past 3 months as keys and 0 as default values
+  // This is done because we might not have any expenses from one of the months
+  // but we still want that month in the map so we have to initialise before
+  const monthlySpendMap = new Map<string, number>();
+  const today = new Date();
+  for (let i = today.getMonth() - 2; i <= today.getMonth(); i++) {
+    monthlySpendMap.set(MONTH_NAMES[i], 0);
+  }
+
+  // Iterate through expenses and update total spending
+  expenses.forEach((expense) => {
+    const month = MONTH_NAMES[expense.date.getMonth()];
+    const currentSpend = monthlySpendMap.get(month) || 0;
+    monthlySpendMap.set(month, currentSpend + expense.amount);
+  });
+
+  const monthlySpendArray = Array.from(monthlySpendMap, ([month, spend]) => {
+    return { month, spend };
+  });
+  return monthlySpendArray;
 };
 
 type CategoryData = Record<ExpenseCategory, {
@@ -173,19 +224,25 @@ export const sortExpenses = (
   expenses: Expense[],
   sortOption: ExpenseSortOption
 ): Expense[] => {
-  if (sortOption === ExpenseSortOption.MOST_RECENT) {
+  if (sortOption === ExpenseSortOption.OLDEST) {
+    return sortOldestExpenses(expenses);
+  } else if (sortOption === ExpenseSortOption.AMOUNT_HIGH_TO_LOW) {
+    return sortMostExpensiveExpenses(expenses);
+  } else if (sortOption === ExpenseSortOption.AMOUNT_LOW_TO_HIGH) {
+    return sortLeastExpensiveExpenses(expenses);
+  } else {
     return sortMostRecentExpenses(expenses);
   }
-  if (sortOption === ExpenseSortOption.AMOUNT_HIGH_TO_LOW) {
-    return sortMostExpensiveExpenses(expenses);
-  }
-  if (sortOption === ExpenseSortOption.AMOUNT_LOW_TO_HIGH) {
-    return sortLeastExpensiveExpenses(expenses);
-  }
-  // Expenses to be passed in will be default expenses with no sorting
-  // It is ordered by oldest by default
-  return expenses;
 };
+
+/**
+ * Sorts the given expenses array by the oldest expenses.
+ * @param expenses An array of {@link Expense} objects.
+ * @returns An array of expense objects with the oldest ones first.
+ */
+const sortOldestExpenses = (expenses: Expense[]): Expense[] => (
+  [...expenses].sort((a, b) => a.date.getTime() - b.date.getTime())
+);
 
 /**
  * Sorts the given expenses array by the most recent expenses.
@@ -194,7 +251,7 @@ export const sortExpenses = (
  */
 const sortMostRecentExpenses = (expenses: Expense[]): Expense[] => (
   // Can use reverse as by default it is the oldest expenses first
-  [...expenses].reverse()
+  [...expenses].sort((a, b) => b.date.getTime() - a.date.getTime())
 );
 
 /**
@@ -304,4 +361,12 @@ const isThisMonth = (date: Date): boolean => {
 const isThisYear = (date: Date): boolean => {
   const today = new Date();
   return date.getFullYear() === today.getFullYear();
+};
+
+const isInPastThreeMonths = (date: Date): boolean => {
+  const today = new Date();
+  const filterStartDate = new Date();
+  filterStartDate.setMonth(today.getMonth() - 3);
+  filterStartDate.setDate(1);
+  return date >= filterStartDate;
 };


### PR DESCRIPTION
Changelog:
- Add monthly stats to the dashboard (home tab)
- Add recent trends to the dashboard
- Add `SafeAreaView` to `ScrollableScreenWrapper` to ensure that scrollable content does not go under the status bar
- Change `<StatusBar>` to be from `react-native` package instead of `expo`
- Fix bug in expense date sorting options